### PR TITLE
Support commenting and un-commenting with `ctrl + /`

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+	<dict>
+		<key>name</key>
+		<string>Comments</string>
+		<key>scope</key>
+		<string>text.html.vento</string>
+		<key>settings</key>
+		<dict>
+			<key>shellVariables</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>TM_COMMENT_START</string>
+					<key>value</key>
+					<string>{{#</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>TM_COMMENT_END</string>
+					<key>value</key>
+					<string>#}}</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</plist>


### PR DESCRIPTION
Adds the `Comments.tmPreferences` definition needed for the `ctrl + /` shortcut for commenting (or un-commenting).