### PR TITLE
Fix of highlighting in for tag

### DIFF
--- a/Syntaxes/JS expression in Vento.sublime-syntax
+++ b/Syntaxes/JS expression in Vento.sublime-syntax
@@ -24,10 +24,10 @@ contexts:
 
   expression-end:
   - meta_prepend: true
+  - match: '(?=\w)'
+    pop: 2
   - match: ''
     pop: 1
-  - match: '(?=\|>|-?}})'
-    pop: true
 
   literal-variable-base:
   - meta_prepend: true

--- a/tests/syntax_test_Vento.txt.vto
+++ b/tests/syntax_test_Vento.txt.vto
@@ -111,6 +111,14 @@
 {{#                                    ^^^^^^^^^^^^^^^^^ source.js.embedded.vento #}}
 {{#                                                      ^^ punctuation.definition.embedded.end.vento #}}
 
+    {{ for item, index of items }}
+{{# ^^ punctuation.definition.embedded.begin.vento #}}
+{{#    ^^^ keyword.control.loop.for.begin.vento #}}
+{{#        ^^^^^^^^^^^ source.js.embedded.vento #}}
+{{#                    ^^ keyword.operator.word #}}
+{{#                       ^^^^^ source.js.embedded.vento #}}
+{{#                             ^^ punctuation.definition.embedded.end.vento #}}
+
     {{ continue }}{{ break }}
 {{# ^^ punctuation.definition.embedded.begin.vento #}}
 {{#    ^^^^^^^^ keyword.control.flow.continue.vento #}}


### PR DESCRIPTION
When doing `{{ for foo of bar }}`, the `of` was incorrectly highlighted as variable, because the expression context wasn't properly broken out of after the `foo`.
